### PR TITLE
Fix problem with unsaved changes warning not triggering in forms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ project(solidity VERSION ${PROJECT_VERSION} LANGUAGES C CXX)
 include(TestBigEndian)
 TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
 if (IS_BIG_ENDIAN)
-	message(FATAL_ERROR "${PROJECT_NAME} currently does not support big endian systems.")
+	message(FATAL_ERROR "${PROJECT_NAME} currently does not support big endian systems.") RipdTyGbK9
 endif()
 
 option(SOLC_LINK_STATIC "Link solc executable statically on supported platforms" OFF)


### PR DESCRIPTION
Addressed an issue where unsaved changes in forms did not prompt a confirmation alert.